### PR TITLE
made longer soldering pads for the HMC5883L

### DIFF
--- a/circuit/eagle/v051/imu/MotionerIMU.brd
+++ b/circuit/eagle/v051/imu/MotionerIMU.brd
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="6.3">
+<eagle version="7.2.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.025" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.005" altunitdist="inch" altunit="inch"/>
+<grid distance="1" unitdist="mm" unit="mm" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="mm" altunit="mm"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
@@ -40,7 +40,7 @@
 <layer number="44" name="Drills" color="7" fill="1" visible="no" active="yes"/>
 <layer number="45" name="Holes" color="7" fill="1" visible="no" active="yes"/>
 <layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
-<layer number="47" name="Measures" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="47" name="Measures" color="7" fill="1" visible="no" active="yes"/>
 <layer number="48" name="Document" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="49" name="Reference" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
@@ -49,6 +49,10 @@
 <layer number="53" name="tGND_GNDA" color="7" fill="9" visible="no" active="no"/>
 <layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
 <layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
+<layer number="57" name="tCAD" color="7" fill="1" visible="no" active="no"/>
+<layer number="59" name="tCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="90" name="Modules" color="5" fill="1" visible="no" active="no"/>
 <layer number="91" name="Nets" color="2" fill="1" visible="no" active="no"/>
 <layer number="92" name="Busses" color="1" fill="1" visible="no" active="no"/>
 <layer number="93" name="Pins" color="2" fill="1" visible="no" active="no"/>
@@ -66,15 +70,32 @@
 <layer number="105" name="tPlate" color="7" fill="1" visible="no" active="yes"/>
 <layer number="106" name="bPlate" color="7" fill="1" visible="no" active="yes"/>
 <layer number="107" name="Crop" color="7" fill="1" visible="no" active="yes"/>
+<layer number="108" name="tplace-old" color="10" fill="1" visible="yes" active="yes"/>
+<layer number="109" name="ref-old" color="11" fill="1" visible="yes" active="yes"/>
 <layer number="110" name="tdokum" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="111" name="bdokum" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="112" name="tSilk" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="113" name="IDFDebug" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="116" name="Patch_BOT" color="9" fill="4" visible="no" active="yes"/>
+<layer number="118" name="Rect_Pads" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="121" name="_tsilk" color="7" fill="1" visible="no" active="yes"/>
 <layer number="122" name="_bsilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="123" name="tTestmark" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="124" name="bTestmark" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="125" name="_tNames" color="7" fill="1" visible="no" active="yes"/>
 <layer number="126" name="_bNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="127" name="_tValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="128" name="_bValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="129" name="Mask" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="131" name="tAdjust" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="132" name="bAdjust" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="144" name="Drill_legend" color="7" fill="1" visible="no" active="yes"/>
+<layer number="150" name="Notes" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="151" name="HeatSink" color="7" fill="1" visible="no" active="yes"/>
+<layer number="152" name="_bDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="153" name="FabDoc1" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="154" name="FabDoc2" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="155" name="FabDoc3" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="199" name="L$199" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="200" name="200bmp" color="1" fill="10" visible="no" active="yes"/>
 <layer number="201" name="201bmp" color="2" fill="10" visible="no" active="yes"/>
@@ -101,9 +122,19 @@
 <layer number="222" name="222bmp" color="23" fill="1" visible="no" active="no"/>
 <layer number="223" name="223bmp" color="24" fill="1" visible="no" active="no"/>
 <layer number="224" name="224bmp" color="25" fill="1" visible="no" active="no"/>
+<layer number="225" name="225bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="226" name="226bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="227" name="227bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="228" name="228bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="229" name="229bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="230" name="230bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="231" name="231bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="248" name="Housing" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="249" name="Edge" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="250" name="Descript" color="3" fill="1" visible="no" active="no"/>
 <layer number="251" name="SMDround" color="12" fill="11" visible="no" active="no"/>
 <layer number="254" name="cooling" color="7" fill="1" visible="no" active="yes"/>
+<layer number="255" name="routoute" color="7" fill="1" visible="yes" active="yes"/>
 </layers>
 <board>
 <plain>
@@ -177,22 +208,22 @@ We've spent an enormous amount of time creating and checking these footprints an
 <wire x1="1.7" y1="1.1" x2="1.7" y2="1.7" width="0.2032" layer="21"/>
 <wire x1="1.7" y1="1.7" x2="1.1" y2="1.7" width="0.2032" layer="21"/>
 <wire x1="-1.28" y1="1.635" x2="-1.635" y2="1.26" width="0.2032" layer="21"/>
-<smd name="4" x="-1.37" y="-0.75" dx="0.65" dy="0.28" layer="1"/>
-<smd name="3" x="-1.37" y="-0.25" dx="0.65" dy="0.28" layer="1"/>
-<smd name="2" x="-1.37" y="0.25" dx="0.65" dy="0.28" layer="1"/>
-<smd name="1" x="-1.37" y="0.75" dx="0.65" dy="0.28" layer="1"/>
-<smd name="5" x="-0.75" y="-1.37" dx="0.65" dy="0.28" layer="1" rot="R270"/>
-<smd name="15" x="-0.25" y="1.37" dx="0.65" dy="0.28" layer="1" rot="R90"/>
-<smd name="14" x="0.25" y="1.37" dx="0.65" dy="0.28" layer="1" rot="R90"/>
-<smd name="13" x="0.75" y="1.37" dx="0.65" dy="0.28" layer="1" rot="R90"/>
-<smd name="12" x="1.37" y="0.75" dx="0.65" dy="0.28" layer="1"/>
-<smd name="11" x="1.37" y="0.25" dx="0.65" dy="0.28" layer="1"/>
-<smd name="10" x="1.37" y="-0.25" dx="0.65" dy="0.28" layer="1"/>
-<smd name="9" x="1.37" y="-0.75" dx="0.65" dy="0.28" layer="1"/>
-<smd name="6" x="-0.25" y="-1.37" dx="0.65" dy="0.28" layer="1" rot="R90"/>
-<smd name="8" x="0.75" y="-1.37" dx="0.65" dy="0.28" layer="1" rot="R90"/>
-<smd name="16" x="-0.75" y="1.37" dx="0.65" dy="0.28" layer="1" rot="R90"/>
-<smd name="7" x="0.25" y="-1.37" dx="0.65" dy="0.28" layer="1" rot="R90"/>
+<smd name="4" x="-1.57" y="-0.75" dx="1.05" dy="0.28" layer="1" roundness="100"/>
+<smd name="3" x="-1.57" y="-0.25" dx="1.05" dy="0.28" layer="1" roundness="100"/>
+<smd name="2" x="-1.57" y="0.25" dx="1.05" dy="0.28" layer="1" roundness="100"/>
+<smd name="1" x="-1.57" y="0.75" dx="1.05" dy="0.28" layer="1" roundness="100"/>
+<smd name="5" x="-0.75" y="-1.57" dx="1.05" dy="0.28" layer="1" roundness="100" rot="R270"/>
+<smd name="15" x="-0.25" y="1.57" dx="1.05" dy="0.28" layer="1" roundness="100" rot="R90"/>
+<smd name="14" x="0.25" y="1.57" dx="1.05" dy="0.28" layer="1" roundness="100" rot="R90"/>
+<smd name="13" x="0.75" y="1.57" dx="1.05" dy="0.28" layer="1" roundness="100" rot="R90"/>
+<smd name="12" x="1.57" y="0.75" dx="1.05" dy="0.28" layer="1" roundness="100"/>
+<smd name="11" x="1.57" y="0.25" dx="1.05" dy="0.28" layer="1" roundness="100"/>
+<smd name="10" x="1.57" y="-0.25" dx="1.05" dy="0.28" layer="1" roundness="100"/>
+<smd name="9" x="1.57" y="-0.75" dx="1.05" dy="0.28" layer="1" roundness="100"/>
+<smd name="6" x="-0.25" y="-1.57" dx="1.05" dy="0.28" layer="1" roundness="100" rot="R90"/>
+<smd name="8" x="0.75" y="-1.57" dx="1.05" dy="0.28" layer="1" roundness="100" rot="R90"/>
+<smd name="16" x="-0.75" y="1.57" dx="1.05" dy="0.28" layer="1" roundness="100" rot="R90"/>
+<smd name="7" x="0.25" y="-1.57" dx="1.05" dy="0.28" layer="1" roundness="100" rot="R90"/>
 <text x="-1.27" y="1.905" size="0.6096" layer="25">&gt;NAME</text>
 <text x="-1.905" y="-2.54" size="0.6096" layer="27">&gt;VALUE</text>
 </package>
@@ -3159,6 +3190,9 @@ design rules under a new name.</description>
 <autorouter>
 <pass name="Default">
 <param name="RoutingGrid" value="1mil"/>
+<param name="AutoGrid" value="1"/>
+<param name="Efforts" value="0"/>
+<param name="TopRouterVariant" value="1"/>
 <param name="tpViaShape" value="round"/>
 <param name="PrefDir.1" value="*"/>
 <param name="PrefDir.2" value="0"/>
@@ -3252,6 +3286,7 @@ design rules under a new name.</description>
 <elements>
 <element name="U5" library="SparkFun-Sensors" package="16LPCC" value="HMC5883L" x="10.16" y="18.415" smashed="yes">
 <attribute name="VALUE" x="13.081" y="16.002" size="0.8128" layer="25" rot="R180"/>
+<attribute name="PROD_ID" value="IC-10284" x="10.16" y="18.415" size="1.778" layer="27" display="off"/>
 </element>
 <element name="U4" library="Testing" package="QFN-24-4MM2" value="MPU-6050-1" x="13.97" y="28.575" smashed="yes" rot="R270"/>
 <element name="U3" library="SparkFun" package="SOT23-5" value="3.3V" x="4.445" y="25.4" smashed="yes">
@@ -3298,8 +3333,8 @@ design rules under a new name.</description>
 </element>
 <element name="JP3" library="SparkFun" package="STAND-OFF-TIGHT" value="STAND-OFFTIGHT" x="39.37" y="30.48" rot="R180"/>
 <element name="JP4" library="SparkFun" package="STAND-OFF-TIGHT" value="STAND-OFFTIGHT" x="2.54" y="2.54" rot="R180"/>
-<element name="JP2" library="SparkFun" package="MICRO-FIDUCIAL" value="FIDUCIALUFIDUCIAL" x="5.715" y="5.715" rot="R180"/>
-<element name="JP5" library="SparkFun" package="MICRO-FIDUCIAL" value="FIDUCIALUFIDUCIAL" x="36.195" y="27.305" rot="R180"/>
+<element name="JP2" library="SparkFun" package="MICRO-FIDUCIAL" value="FIDUCIALUFIDUCIAL" x="1.905" y="29.21" rot="R180"/>
+<element name="JP5" library="SparkFun" package="MICRO-FIDUCIAL" value="FIDUCIALUFIDUCIAL" x="39.37" y="3.175" rot="R180"/>
 <element name="U$2" library="SparkFun-Aesthetics" package="OSHW-LOGO-S" value="OSHW-LOGOS" x="38.1" y="3.302" rot="MR0"/>
 <element name="U2" library="SparkFun" package="SOT23-5" value="5V" x="11.43" y="6.985" smashed="yes" rot="R90">
 <attribute name="VALUE" x="11.7475" y="6.2865" size="0.8128" layer="25" rot="R90"/>
@@ -3494,15 +3529,12 @@ design rules under a new name.</description>
 <wire x1="18.8976" y1="18.415" x2="19.6088" y2="17.7038" width="0.254" layer="1"/>
 <wire x1="18.415" y1="18.415" x2="18.8976" y2="18.415" width="0.254" layer="1"/>
 <wire x1="22.8346" y1="13.335" x2="22.845" y2="13.335" width="0.254" layer="1"/>
-<wire x1="13.589" y1="18.669" x2="12.192" y2="18.669" width="0.254" layer="1"/>
-<wire x1="12.192" y1="18.669" x2="11.5316" y2="18.669" width="0.254" layer="1"/>
+<wire x1="13.589" y1="18.669" x2="13" y2="18.669" width="0.254" layer="1"/>
+<wire x1="13" y1="18.669" x2="11.5316" y2="18.669" width="0.254" layer="1"/>
 <wire x1="13.97" y1="19.05" x2="13.589" y2="18.669" width="0.254" layer="1"/>
-<wire x1="11.5316" y1="18.669" x2="11.53" y2="18.665" width="0.254" layer="1"/>
+<wire x1="11.5316" y1="18.669" x2="11.73" y2="18.665" width="0.254" layer="1"/>
 <wire x1="13.97" y1="19.05" x2="13.97" y2="19.065" width="0.254" layer="1"/>
-<wire x1="11.9888" y1="17.6784" x2="11.5316" y2="17.6784" width="0.254" layer="1"/>
-<wire x1="12.192" y1="17.8816" x2="11.9888" y2="17.6784" width="0.254" layer="1"/>
-<wire x1="12.192" y1="18.669" x2="12.192" y2="17.8816" width="0.254" layer="1"/>
-<wire x1="11.5316" y1="17.6784" x2="11.53" y2="17.665" width="0.254" layer="1"/>
+<wire x1="11.5316" y1="17.6784" x2="11.73" y2="17.665" width="0.254" layer="1"/>
 <wire x1="14.6558" y1="23.5204" x2="17.2466" y2="23.5204" width="0.254" layer="1"/>
 <wire x1="17.2466" y1="23.5204" x2="18.415" y2="23.5204" width="0.254" layer="1"/>
 <wire x1="14.6304" y1="23.495" x2="14.6558" y2="23.5204" width="0.254" layer="1"/>
@@ -3628,6 +3660,11 @@ design rules under a new name.</description>
 <vertex x="1.27" y="0"/>
 <vertex x="38.1" y="0"/>
 </polygon>
+<wire x1="11.9888" y1="17.6784" x2="11.5316" y2="17.6784" width="0.254" layer="1"/>
+<wire x1="11.9888" y1="17.6784" x2="11.9972" y2="17.67" width="0.254" layer="1"/>
+<wire x1="11.9972" y1="17.67" x2="12.5" y2="17.67" width="0.254" layer="1"/>
+<wire x1="12.5" y1="17.67" x2="13" y2="18.17" width="0.254" layer="1"/>
+<wire x1="13" y1="18.17" x2="13" y2="18.669" width="0.254" layer="1"/>
 </signal>
 <signal name="3.3V" class="4">
 <contactref element="U3" pad="5"/>
@@ -3644,18 +3681,7 @@ design rules under a new name.</description>
 <contactref element="C11" pad="1"/>
 <contactref element="R2" pad="2"/>
 <contactref element="R3" pad="2"/>
-<wire x1="8.3312" y1="18.6436" x2="8.7884" y2="18.6436" width="0.254" layer="1"/>
-<wire x1="8.128" y1="18.4404" x2="8.3312" y2="18.6436" width="0.254" layer="1"/>
-<wire x1="8.128" y1="17.8816" x2="8.128" y2="18.4404" width="0.254" layer="1"/>
-<wire x1="8.3312" y1="17.6784" x2="8.128" y2="17.8816" width="0.254" layer="1"/>
-<wire x1="8.7884" y1="17.6784" x2="8.3312" y2="17.6784" width="0.254" layer="1"/>
-<wire x1="8.7884" y1="18.6436" x2="8.79" y2="18.665" width="0.254" layer="1"/>
-<wire x1="8.7884" y1="17.6784" x2="8.79" y2="17.665" width="0.254" layer="1"/>
-<wire x1="9.4996" y1="16.002" x2="9.4996" y2="13.97" width="0.254" layer="1"/>
-<wire x1="8.8392" y1="16.6624" x2="9.4996" y2="16.002" width="0.254" layer="1"/>
-<wire x1="8.8392" y1="17.5514" x2="8.8392" y2="16.6624" width="0.254" layer="1"/>
 <wire x1="9.4996" y1="13.97" x2="9.51" y2="13.97" width="0.254" layer="1"/>
-<wire x1="8.8392" y1="17.5514" x2="8.79" y2="17.665" width="0.254" layer="1"/>
 <wire x1="3.7846" y1="28.575" x2="3.7846" y2="29.5148" width="0.254" layer="1"/>
 <wire x1="3.7846" y1="29.5148" x2="3.7846" y2="30.48" width="0.254" layer="1"/>
 <wire x1="3.7846" y1="30.48" x2="3.795" y2="30.48" width="0.254" layer="1"/>
@@ -3676,7 +3702,7 @@ design rules under a new name.</description>
 <wire x1="13.0556" y1="21.59" x2="12.4587" y2="20.9931" width="0.254" layer="1"/>
 <wire x1="12.4587" y1="20.9931" x2="11.2522" y2="19.7866" width="0.254" layer="1"/>
 <wire x1="13.32" y1="21.59" x2="13.0556" y2="21.59" width="0.254" layer="1"/>
-<wire x1="10.922" y1="19.7866" x2="10.91" y2="19.785" width="0.254" layer="1"/>
+<wire x1="10.922" y1="19.7866" x2="10.91" y2="19.985" width="0.254" layer="1"/>
 <wire x1="13.3096" y1="21.6916" x2="13.3096" y2="23.495" width="0.254" layer="1"/>
 <wire x1="13.3096" y1="23.495" x2="13.32" y2="23.495" width="0.254" layer="1"/>
 <wire x1="13.3096" y1="21.6916" x2="13.32" y2="21.59" width="0.254" layer="1"/>
@@ -3697,15 +3723,31 @@ design rules under a new name.</description>
 <wire x1="6.731" y1="29.5148" x2="3.7846" y2="29.5148" width="0.254" layer="1"/>
 <wire x1="10.5156" y1="29.5148" x2="6.731" y2="29.5148" width="0.254" layer="16"/>
 <wire x1="10.5156" y1="29.5148" x2="10.6172" y2="29.6926" width="0.254" layer="16"/>
-<wire x1="7.493" y1="19.5072" x2="8.255" y2="18.7452" width="0.254" layer="1"/>
 <wire x1="7.493" y1="20.7264" x2="7.493" y2="19.5072" width="0.254" layer="1"/>
 <wire x1="9.1186" y1="22.352" x2="7.493" y2="20.7264" width="0.254" layer="1"/>
 <wire x1="11.0998" y1="22.352" x2="9.1186" y2="22.352" width="0.254" layer="1"/>
-<wire x1="8.255" y1="18.7452" x2="8.3312" y2="18.6436" width="0.254" layer="1"/>
 <wire x1="11.0998" y1="22.352" x2="12.4587" y2="20.9931" width="0.254" layer="1"/>
 <via x="10.6172" y="29.6926" extent="1-16" drill="0.6096"/>
 <via x="11.811" y="26.4414" extent="1-16" drill="0.6096"/>
 <via x="6.731" y="29.5148" extent="1-16" drill="0.6096"/>
+<wire x1="7.493" y1="19.5072" x2="7.49" y2="19.5042" width="0.254" layer="1"/>
+<wire x1="7.49" y1="19.5042" x2="7.49" y2="18.85" width="0.254" layer="1"/>
+<wire x1="7.49" y1="18.85" x2="7.675" y2="18.665" width="0.254" layer="1"/>
+<wire x1="7.675" y1="18.665" x2="8.59" y2="18.665" width="0.254" layer="1"/>
+<wire x1="8.59" y1="18.665" x2="8.585" y2="18.67" width="0.254" layer="1"/>
+<wire x1="8.585" y1="18.67" x2="7.77" y2="18.67" width="0.254" layer="1"/>
+<wire x1="7.77" y1="18.67" x2="7.8" y2="18.64" width="0.254" layer="1"/>
+<wire x1="7.8" y1="18.64" x2="7.8" y2="18.06" width="0.254" layer="1"/>
+<wire x1="7.8" y1="18.06" x2="7.78" y2="18.04" width="0.254" layer="1"/>
+<wire x1="7.78" y1="18.04" x2="7.78" y2="18.01" width="0.254" layer="1"/>
+<wire x1="7.78" y1="18.01" x2="8.125" y2="17.665" width="0.254" layer="1"/>
+<wire x1="8.125" y1="17.665" x2="8.59" y2="17.665" width="0.254" layer="1"/>
+<wire x1="8.8392" y1="17.5514" x2="8.92" y2="17.4706" width="0.254" layer="1"/>
+<wire x1="8.92" y1="17.4706" x2="8.92" y2="15.18" width="0.254" layer="1"/>
+<wire x1="8.92" y1="15.18" x2="9.51" y2="14.59" width="0.254" layer="1"/>
+<wire x1="9.51" y1="14.59" x2="9.51" y2="13.97" width="0.254" layer="1"/>
+<wire x1="8.59" y1="17.665" x2="8.7036" y2="17.5514" width="0.254" layer="1"/>
+<wire x1="8.7036" y1="17.5514" x2="8.8392" y2="17.5514" width="0.254" layer="1"/>
 </signal>
 <signal name="SDA">
 <contactref element="U4" pad="24"/>
@@ -3744,37 +3786,37 @@ design rules under a new name.</description>
 <contactref element="C4" pad="1"/>
 <wire x1="10.4902" y1="18.161" x2="11.5062" y2="18.161" width="0.254" layer="1"/>
 <wire x1="11.938" y1="18.161" x2="10.4902" y2="18.161" width="0.254" layer="16"/>
-<wire x1="12.8016" y1="17.2974" x2="11.938" y2="18.161" width="0.254" layer="16"/>
-<wire x1="13.5128" y1="17.2974" x2="12.8016" y2="17.2974" width="0.254" layer="1"/>
+<wire x1="13.0216" y1="17.0574" x2="11.938" y2="18.161" width="0.254" layer="16"/>
+<wire x1="13.5128" y1="17.2974" x2="13.0216" y2="17.0574" width="0.254" layer="1"/>
 <wire x1="13.97" y1="17.7546" x2="13.5128" y2="17.2974" width="0.254" layer="1"/>
-<wire x1="11.5062" y1="18.161" x2="11.53" y2="18.165" width="0.254" layer="1"/>
+<wire x1="11.5062" y1="18.161" x2="11.73" y2="18.165" width="0.254" layer="1"/>
 <wire x1="13.97" y1="17.7546" x2="13.97" y2="17.765" width="0.254" layer="1"/>
 <via x="10.4902" y="18.161" extent="1-16" drill="0.6096"/>
-<via x="12.8016" y="17.2974" extent="1-16" drill="0.6096"/>
+<via x="13.0216" y="17.0574" extent="1-16" drill="0.6096"/>
 </signal>
 <signal name="N$4">
 <contactref element="U5" pad="8"/>
 <contactref element="C5" pad="1"/>
-<wire x1="11.8618" y1="17.0434" x2="10.922" y2="17.0434" width="0.254" layer="1"/>
 <wire x1="12.8524" y1="16.0528" x2="11.8618" y2="17.0434" width="0.254" layer="1"/>
 <wire x1="15.2654" y1="16.0528" x2="12.8524" y2="16.0528" width="0.254" layer="1"/>
 <wire x1="15.875" y1="16.6624" x2="15.2654" y2="16.0528" width="0.254" layer="1"/>
 <wire x1="15.875" y1="17.765" x2="15.875" y2="16.6624" width="0.254" layer="1"/>
-<wire x1="10.922" y1="17.0434" x2="10.91" y2="17.045" width="0.254" layer="1"/>
+<wire x1="10.922" y1="17.0434" x2="10.91" y2="16.845" width="0.254" layer="1"/>
+<wire x1="11.8618" y1="17.0434" x2="10.922" y2="17.0434" width="0.254" layer="1"/>
 </signal>
 <signal name="N$5">
 <contactref element="C5" pad="2"/>
 <contactref element="U5" pad="12"/>
 <wire x1="11.8364" y1="19.177" x2="11.5316" y2="19.177" width="0.254" layer="1"/>
-<wire x1="12.4206" y1="19.7612" x2="11.8364" y2="19.177" width="0.254" layer="1"/>
-<wire x1="12.4206" y1="19.3802" x2="12.4206" y2="19.7612" width="0.254" layer="16"/>
+<wire x1="12.6746" y1="19.8882" x2="11.8364" y2="19.177" width="0.254" layer="1"/>
 <wire x1="14.9098" y1="16.891" x2="12.4206" y2="19.3802" width="0.254" layer="16"/>
 <wire x1="14.9098" y1="18.0848" x2="14.9098" y2="16.891" width="0.254" layer="1"/>
 <wire x1="15.875" y1="19.05" x2="14.9098" y2="18.0848" width="0.254" layer="1"/>
-<wire x1="11.5316" y1="19.177" x2="11.53" y2="19.165" width="0.254" layer="1"/>
+<wire x1="11.5316" y1="19.177" x2="11.73" y2="19.165" width="0.254" layer="1"/>
 <wire x1="15.875" y1="19.05" x2="15.875" y2="19.065" width="0.254" layer="1"/>
-<via x="12.4206" y="19.7612" extent="1-16" drill="0.6096"/>
+<via x="12.6746" y="19.8882" extent="1-16" drill="0.6096"/>
 <via x="14.9098" y="16.891" extent="1-16" drill="0.6096"/>
+<wire x1="12.4206" y1="19.3802" x2="12.6746" y2="19.8882" width="0.254" layer="16"/>
 </signal>
 <signal name="N$6">
 <contactref element="U4" pad="20"/>
@@ -4266,7 +4308,7 @@ design rules under a new name.</description>
 <wire x1="11.7856" y1="30.6832" x2="12.6492" y2="29.8196" width="0.254" layer="16"/>
 <wire x1="11.7856" y1="29.9212" x2="11.7856" y2="30.6832" width="0.254" layer="1"/>
 <wire x1="11.8618" y1="29.845" x2="11.7856" y2="29.9212" width="0.254" layer="1"/>
-<wire x1="8.8138" y1="19.177" x2="8.79" y2="19.165" width="0.254" layer="1"/>
+<wire x1="8.8138" y1="19.177" x2="8.59" y2="19.165" width="0.254" layer="1"/>
 <wire x1="11.8618" y1="29.845" x2="11.8484" y2="29.8417" width="0.254" layer="1"/>
 <via x="9.4742" y="21.5138" extent="1-16" drill="0.6096"/>
 <via x="11.7856" y="30.6832" extent="1-16" drill="0.6096"/>
@@ -4275,9 +4317,7 @@ design rules under a new name.</description>
 <contactref element="U4" pad="6"/>
 <contactref element="U5" pad="16"/>
 <wire x1="9.4234" y1="20.2438" x2="9.4234" y2="19.7866" width="0.254" layer="1"/>
-<wire x1="10.0076" y1="20.828" x2="9.4234" y2="20.2438" width="0.254" layer="1"/>
-<wire x1="10.5156" y1="20.828" x2="10.0076" y2="20.828" width="0.254" layer="1"/>
-<wire x1="9.9822" y1="20.828" x2="10.5156" y2="20.828" width="0.254" layer="16"/>
+<wire x1="9.9822" y1="20.828" x2="10.7956" y2="21.268" width="0.254" layer="16"/>
 <wire x1="9.8298" y1="20.6756" x2="9.9822" y2="20.828" width="0.254" layer="16"/>
 <wire x1="9.1186" y1="20.6756" x2="9.8298" y2="20.6756" width="0.254" layer="16"/>
 <wire x1="5.8928" y1="23.9014" x2="9.1186" y2="20.6756" width="0.254" layer="16"/>
@@ -4286,10 +4326,12 @@ design rules under a new name.</description>
 <wire x1="12.0142" y1="31.6484" x2="7.6708" y2="31.6484" width="0.254" layer="1"/>
 <wire x1="12.6492" y1="31.0134" x2="12.0142" y2="31.6484" width="0.254" layer="1"/>
 <wire x1="12.6492" y1="30.6578" x2="12.6492" y2="31.0134" width="0.254" layer="1"/>
-<wire x1="9.4234" y1="19.7866" x2="9.41" y2="19.785" width="0.254" layer="1"/>
+<wire x1="9.4234" y1="19.7866" x2="9.41" y2="19.985" width="0.254" layer="1"/>
 <wire x1="12.6492" y1="30.6578" x2="12.6733" y2="30.6412" width="0.254" layer="1"/>
-<via x="10.5156" y="20.828" extent="1-16" drill="0.6096"/>
+<via x="10.7956" y="21.268" extent="1-16" drill="0.6096"/>
 <via x="7.6708" y="31.6484" extent="1-16" drill="0.6096"/>
+<wire x1="10.7956" y1="21.268" x2="9.4176" y2="20.598" width="0.254" layer="1"/>
+<wire x1="9.4176" y1="20.598" x2="9.4234" y2="20.2438" width="0.254" layer="1"/>
 </signal>
 </signals>
 </board>


### PR DESCRIPTION
The solder pads of the HMC5883L from the Sparkfun eagle library that you used are too small, they are really hard to position the sensor and don't allow you to check if the pads are correctly soldered. I made longer pads like the ones you made for the MPU-6050, since I could even re-solder the pads with my soldering iron.

it was like this:
![captura de tela 2015-07-21 as 02 23 26](https://cloud.githubusercontent.com/assets/5085536/8793621/111168e6-2f50-11e5-9e8a-14bdc1a804ef.png)

now I changed it to this:
![captura de tela 2015-07-21 as 00 41 11](https://cloud.githubusercontent.com/assets/5085536/8793627/24cb3cb8-2f50-11e5-9dc0-22e8477c111f.png)
